### PR TITLE
Move from tokio-core to tokio.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,18 +12,18 @@ keywords = ["xmpp", "tokio"]
 
 [dependencies]
 futures = "0.1"
-tokio-core = "0.1"
+tokio = "0.1"
 tokio-io = "0.1"
 tokio-codec = "0.1"
 bytes = "0.4.9"
 xml5ever = "0.12"
 minidom = "0.9"
-# TODO: update to 0.2.0
-native-tls = "0.1"
-tokio-tls = "0.1"
+native-tls = "0.2"
+tokio-tls = "0.2"
 sasl = "0.4"
 jid = { version = "0.5", features = ["minidom"] }
-domain = "0.2"
+trust-dns-resolver = "0.9.1"
+trust-dns-proto = "0.4.0"
 xmpp-parsers = "0.11"
 idna = "0.1"
 try_from = "0.2"

--- a/examples/echo_bot.rs
+++ b/examples/echo_bot.rs
@@ -1,5 +1,5 @@
 extern crate futures;
-extern crate tokio_core;
+extern crate tokio;
 extern crate tokio_xmpp;
 extern crate jid;
 extern crate minidom;
@@ -9,8 +9,8 @@ extern crate try_from;
 use std::env::args;
 use std::process::exit;
 use try_from::TryFrom;
-use tokio_core::reactor::Core;
 use futures::{Stream, Sink, future};
+use tokio::runtime::current_thread::Runtime;
 use tokio_xmpp::Client;
 use minidom::Element;
 use xmpp_parsers::presence::{Presence, Type as PresenceType, Show as PresenceShow};
@@ -27,9 +27,9 @@ fn main() {
     let password = &args[2];
 
     // tokio_core context
-    let mut core = Core::new().unwrap();
+    let mut rt = Runtime::new().unwrap();
     // Client instance
-    let client = Client::new(jid, password, core.handle()).unwrap();
+    let client = Client::new(jid, password).unwrap();
 
     // Make the two interfaces for sending and receiving independent
     // of each other so we can move one into a closure.
@@ -64,7 +64,7 @@ fn main() {
     });
 
     // Start polling `done`
-    match core.run(done) {
+    match rt.block_on(done) {
         Ok(_) => (),
         Err(e) => {
             println!("Fatal: {}", e);

--- a/examples/echo_component.rs
+++ b/examples/echo_component.rs
@@ -1,5 +1,5 @@
 extern crate futures;
-extern crate tokio_core;
+extern crate tokio;
 extern crate tokio_xmpp;
 extern crate jid;
 extern crate minidom;
@@ -10,7 +10,7 @@ use std::env::args;
 use std::process::exit;
 use std::str::FromStr;
 use try_from::TryFrom;
-use tokio_core::reactor::Core;
+use tokio::runtime::current_thread::Runtime;
 use futures::{Stream, Sink, future};
 use tokio_xmpp::Component;
 use minidom::Element;
@@ -30,10 +30,10 @@ fn main() {
     let port: u16 = args.get(4).unwrap().parse().unwrap_or(5347u16);
 
     // tokio_core context
-    let mut core = Core::new().unwrap();
+    let mut rt = Runtime::new().unwrap();
     // Component instance
-    println!("{} {} {} {} {:?}", jid, password, server, port, core.handle());
-    let component = Component::new(jid, password, server, port, core.handle()).unwrap();
+    println!("{} {} {} {}", jid, password, server, port);
+    let component = Component::new(jid, password, server, port).unwrap();
 
     // Make the two interfaces for sending and receiving independent
     // of each other so we can move one into a closure.
@@ -70,7 +70,7 @@ fn main() {
     });
 
     // Start polling `done`
-    match core.run(done) {
+    match rt.block_on(done) {
         Ok(_) => (),
         Err(e) => {
             println!("Fatal: {}", e);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! XMPP implemeentation with asynchronous I/O using Tokio.
 
 extern crate futures;
-extern crate tokio_core;
+extern crate tokio;
 extern crate tokio_io;
 extern crate tokio_codec;
 extern crate bytes;
@@ -14,7 +14,8 @@ extern crate native_tls;
 extern crate tokio_tls;
 extern crate sasl;
 extern crate jid;
-extern crate domain;
+extern crate trust_dns_resolver;
+extern crate trust_dns_proto;
 extern crate idna;
 extern crate xmpp_parsers;
 extern crate try_from;

--- a/src/starttls.rs
+++ b/src/starttls.rs
@@ -3,8 +3,8 @@ use futures::{Future, Sink, Poll, Async};
 use futures::stream::Stream;
 use futures::sink;
 use tokio_io::{AsyncRead, AsyncWrite};
-use tokio_tls::{TlsStream, TlsConnectorExt, ConnectAsync};
-use native_tls::TlsConnector;
+use tokio_tls::{TlsStream, TlsConnector, Connect};
+use native_tls::TlsConnector as NativeTlsConnector;
 use minidom::Element;
 use jid::Jid;
 
@@ -25,7 +25,7 @@ enum StartTlsClientState<S: AsyncRead + AsyncWrite> {
     Invalid,
     SendStartTls(sink::Send<XMPPStream<S>>),
     AwaitProceed(XMPPStream<S>),
-    StartingTls(ConnectAsync<S>),
+    StartingTls(Connect<S>),
 }
 
 impl<S: AsyncRead + AsyncWrite> StartTlsClient<S> {
@@ -53,7 +53,7 @@ impl<S: AsyncRead + AsyncWrite> Future for StartTlsClient<S> {
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         let old_state = replace(&mut self.state, StartTlsClientState::Invalid);
         let mut retry = false;
-        
+
         let (new_state, result) = match old_state {
             StartTlsClientState::SendStartTls(mut send) =>
                 match send.poll() {
@@ -73,9 +73,9 @@ impl<S: AsyncRead + AsyncWrite> Future for StartTlsClient<S> {
                         if stanza.name() == "proceed" =>
                     {
                         let stream = xmpp_stream.stream.into_inner();
-                        let connect = TlsConnector::builder().unwrap()
-                            .build().unwrap()
-                            .connect_async(&self.jid.domain, stream);
+                        let connect = TlsConnector::from(NativeTlsConnector::builder()
+                            .build().unwrap())
+                            .connect(&self.jid.domain, stream);
                         let new_state = StartTlsClientState::StartingTls(connect);
                         retry = true;
                         (new_state, Ok(Async::NotReady))


### PR DESCRIPTION
Fix #2.

Removes deprecated `tokio-core` and `domains` and use `tokio` and `trust-dns`.

I fully rewrote `happy_eyeballs.rs` so I hope nothing was broken. Echo client works. Echo component wasn't tested.